### PR TITLE
productionのconfig.assets.compileをtrueに変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
steｐ3 のreview合格後、プルリクmergeしたら、
Herokuのアプリが開かない。
Herokuのサイトで確認して、自動デプロイはsucceedになっている。

step3でjquery, bootstrapを導入したので、本番環境のアセットパイプライン設定が原因と予想。
step3ブランチからもう一度pushして、masterにmergeして、herokuアプリが立ち上がるか確認する。